### PR TITLE
Feature/leastpriv policy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,9 @@ scripts/test.csv
 # Shell scripts (if they contain sensitive info)
 #--------------------------------------------------
 lambda/build_lambda.sh
+
+#--------------------------------------------------
+# Access Analyzer findings & generated policy outputs
+#--------------------------------------------------
+scripts/access_analyzer_findings.json
+scripts/generated_policies/

--- a/scripts/fetch_findings.py
+++ b/scripts/fetch_findings.py
@@ -1,0 +1,36 @@
+import json
+import boto3
+
+# Load latest.json
+with open('../lambdas/analyzer/modules/latest.json', 'r') as f:
+    latest = json.load(f)
+
+# Initialize Access Analyzer client
+client = boto3.client('accessanalyzer', region_name='us-east-2')
+
+# Set the analyzer name
+ANALYZER_ARN = 'arn:aws:access-analyzer:us-east-2:904610147891:analyzer/scopedown-analyzer'
+
+def get_findings_for_arn(analyzer_name, resource_arn):
+    paginator = client.get_paginator('list_findings_v2')
+    findings = []
+    for page in paginator.paginate(analyzerArn=ANALYZER_ARN, filter={'resource': {'eq': [resource_arn]}}):
+        findings.extend(page['findings'])
+    return findings
+
+# Collect findings for each IAM resource
+all_findings = {}
+
+for resource_type in ['aws_iam_user', 'aws_iam_role']:
+    for resource in latest.get(resource_type, []):
+        arn = resource['arn']
+        tf_resource_name = resource['tf_resource_name']
+        print(f"Fetching findings for {tf_resource_name} ({arn})...")
+        findings = get_findings_for_arn(ANALYZER_ARN, arn)
+        all_findings[tf_resource_name] = findings
+
+# Save findings to a file for later use
+with open('access_analyzer_findings.json', 'w') as f:
+    json.dump(all_findings, f, indent=2)
+
+print("Done! Findings written to access_analyzer_findings.json")

--- a/scripts/gen_leastpriv_policies.py
+++ b/scripts/gen_leastpriv_policies.py
@@ -1,0 +1,54 @@
+import json
+import os
+
+FINDINGS_FILE = 'access_analyzer_findings.json'
+OUTPUT_DIR = 'generated_policies'
+
+# Ensure output directory exists
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+def generate_policy_block(resource_name, findings):
+    """
+    Returns a Terraform HCL string for an aws_iam_policy resource.
+    """
+    statements = []
+    for finding in findings:
+        actions = finding.get('actions', [])
+        resources = finding.get('resources', [])
+        if actions and resources:
+            statements.append({
+                "Effect": "Allow",
+                "Action": actions,
+                "Resource": resources
+            })
+    if not statements:
+        # If no findings, create an empty deny-all policy or skip
+        return None
+
+    policy_block = f'''
+resource "aws_iam_policy" "least_privilege_{resource_name}" {{
+  name   = "least-privilege-{resource_name}"
+  policy = jsonencode({{
+    "Version": "2012-10-17",
+    "Statement": {json.dumps(statements, indent=4)}
+  }})
+}}
+'''
+    return policy_block
+
+def main():
+    with open(FINDINGS_FILE, 'r') as f:
+        findings_data = json.load(f)
+
+    for resource_name, findings in findings_data.items():
+        policy_hcl = generate_policy_block(resource_name, findings)
+        if policy_hcl:
+            output_path = os.path.join(OUTPUT_DIR, f'least_privilege_{resource_name}.tf')
+            with open(output_path, 'w') as out_f:
+                out_f.write(policy_hcl)
+            print(f"Generated policy for {resource_name}: {output_path}")
+        else:
+            print(f"No findings for {resource_name}, no policy generated.")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds scripts for fetching IAM resource findings from Access Analyzer and generating least-privilege Terraform IAM policy blocks for each resource. Scripts are located in scripts/ and output is ignored from version control. Ready for integration and further testing with real findings, but otherwise has been tested locally for valid outputs.
