### PR TITLE
🔒 Remove 18 unused IAM permissions across 2 users

### DIFF
--- a/iam-analysis-results.md
+++ b/iam-analysis-results.md
@@ -1,0 +1,33 @@
+# IAM Analysis Results
+
+Generated: 2025-06-26 18:48:10
+
+## Summary
+- Users analyzed: 2
+- Policies updated: 2
+- Files modified: 1
+- Total unused permissions removed: 18
+
+## Files Modified
+
+### infra/sample-iac-app/terraform/policies.tf
+- Policies updated: 2
+- Unused permissions removed: 18
+  - **alice-analyst-test** (alice_analyst_policy): 10 unused actions
+  - **bob-dev-test** (bob_dev_policy): 8 unused actions
+
+## Detailed Findings
+
+### aws_iam_user_policy.alice_analyst_policy
+- User: alice-analyst-test
+- Policy: alice-analyst-test-policy
+- File: infra/sample-iac-app/terraform/policies.tf
+- Unused actions: 10
+- Actions: s3:PutObject, s3:DeleteObject, athena:CreateDataCatalog, athena:DeleteWorkGroup, glue:*, dynamodb:Scan, iam:List*, iam:Get* (and 2 more)
+
+### aws_iam_user_policy.bob_dev_policy
+- User: bob-dev-test
+- Policy: bob-dev-test-policy
+- File: infra/sample-iac-app/terraform/policies.tf
+- Unused actions: 8
+- Actions: lambda:CreateFunction, lambda:DeleteFunction, lambda:UpdateFunctionCode, s3:DeleteObject, s3:PutBucketPolicy, iam:GetRole, iam:ListRoles, logs:PutLogEvents

--- a/iam-policies.tf
+++ b/iam-policies.tf
@@ -1,0 +1,93 @@
+# IAM Users and Policies
+# This file contains IAM resources for our application
+
+resource "aws_iam_user" "alice_analyst" {
+  name = "alice-analyst-test"
+  path = "/analysts/"
+  
+  tags = {
+    Department = "Analytics"
+    Purpose    = "DataAnalysis"
+  }
+}
+
+resource "aws_iam_user" "bob_developer" {
+  name = "bob-dev-test"
+  path = "/developers/"
+  
+  tags = {
+    Department = "Engineering"
+    Purpose    = "Development"
+  }
+}
+
+resource "aws_iam_user_policy" "alice_analyst_policy" {
+  name = "alice-analyst-policy"
+  user = aws_iam_user.alice_analyst.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AnalyticsAccess"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "athena:StartQueryExecution",
+          "athena:GetQueryResults",
+          "athena:CreateDataCatalog",
+          "athena:DeleteWorkGroup",
+          "glue:*",
+          "dynamodb:Scan",
+          "iam:List*",
+          "iam:Get*",
+          "lambda:InvokeFunction",
+          "sts:AssumeRole",
+          "cloudwatch:PutMetricData",
+          "kms:Decrypt"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy" "bob_developer_policy" {
+  name = "bob-developer-policy"
+  user = aws_iam_user.bob_developer.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DeveloperAccess"
+        Effect = "Allow"
+        Action = [
+          "lambda:CreateFunction",
+          "lambda:DeleteFunction",
+          "lambda:UpdateFunctionCode",
+          "lambda:InvokeFunction",
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:PutBucketPolicy",
+          "iam:GetRole",
+          "iam:ListRoles",
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "cloudwatch:PutMetricData"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# Additional resources...
+resource "aws_s3_bucket" "app_data" {
+  bucket = "my-app-data-bucket"
+}


### PR DESCRIPTION
## 🔒 IAM Least Privilege Optimization

**Generated:** 2025-06-26 18:48:15 UTC

### 📊 Summary
- **Users analyzed:** 2
- **Policies updated:** 2
- **Files modified:** 1
- **Total unused permissions removed:** 18

### 📁 Files Changed

#### `infra/sample-iac-app/terraform/policies.tf`
- **Policies updated:** 2
- **Unused permissions removed:** 18
  - **alice-analyst-test** (`alice_analyst_policy`): 10 unused actions
  - **bob-dev-test** (`bob_dev_policy`): 8 unused actions

#### `iam-analysis-results.md`
- **Type:** Detailed analysis report
- **Content:** Complete findings and recommendations

### 🛡️ Security Impact
This PR implements the **principle of least privilege** by:
- Removing unused IAM permissions identified by AWS Access Analyzer
- Reducing the attack surface for each IAM user
- Maintaining only the minimum required permissions for functionality

### ✅ Review Checklist
- [ ] Review the specific permissions being removed for each user
- [ ] Verify that removed permissions are not required for current workflows
- [ ] Test the changes in a non-production environment
- [ ] Confirm that applications/scripts still function correctly
- [ ] Check that CI/CD pipelines continue to work

### 🔍 Detailed Analysis
For complete details about the analysis, findings, and recommendations, see the `iam-analysis-results.md` file in this PR.

**⚠️ Important:** Always test these changes in a development environment before applying to production.
